### PR TITLE
Add 'pageName' configuration as a property

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ class App extends Component {
           accessToken={`${YOUR_EMBED_TOKEN}`}
           filterPaneEnabled={false}
           navContentPaneEnabled={false}
+          pageName={`${YOUR_PAGE_ID}`}
           width='600px'
           height='900px'
         />

--- a/src/index.js
+++ b/src/index.js
@@ -45,6 +45,7 @@ class PowerbiEmbedded extends React.Component {
 
   updateState (props) {
     const nextState = Object.assign({}, this.state, props, {
+      pageName: this.props.pageName,
       settings: {
         filterPaneEnabled: this.props.filterPaneEnabled,
         navContentPaneEnabled: this.props.navContentPaneEnabled,


### PR DESCRIPTION
Hi,

This library we've found to be very useful so far. We need to add the capability to specify a page by ID to load when the report loads. This change allows that by accepting `pageName` as a property which passes on to the PowerBI-Client API behind the scenes. 

I've tested locally on a multi-page report, with both nav enabled and disabled and this appears to work fine.

(I haven't bumped version numbers in this PR, but if you're happy with it then publishing to NPM a new version would be very helpful!)

Happy for feedback.

Thanks,
Dave