### PR TITLE
Remove console logs from index.validateConfig

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -63,11 +63,7 @@ class PowerbiEmbedded extends React.Component {
   }
 
   validateConfig (config) {
-    console.log(config)
     const errors = pbi.models.validateReportLoad(config)
-
-    // console.dir(pbi.service.Service)
-    console.log('error', errors)
     return (errors === undefined)
   }
 


### PR DESCRIPTION
Removing console logs so potentially privileged information is not exposed in the console.